### PR TITLE
Add anti-disconnect jazz from cisagov/pca-gophish-composition-packer

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,6 +7,6 @@ import_heading_thirdparty=Third-Party Libraries
 import_heading_firstparty=cisagov Libraries
 
 # Should be auto-populated by seed-isort-config hook
-known_third_party=pytest,testinfra
+known_third_party=testinfra
 # These must be manually set to correctly separate them from third party libraries
 known_first_party=

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -74,8 +74,13 @@ platforms:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
   #   command: /lib/systemd/systemd
   #   pre_build_image: yes
-  - name: kali
-    image: kalilinux/kali-rolling
+  - name: kali_systemd
+    image: cisagov/docker-kali-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,7 +12,17 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("x", [True])
-def test_packages(host, x):
-    """Run a dummy test, just to show what one would look like."""
-    assert x
+def test_packages(host):
+    """Test that the appropriate packages were installed."""
+    distribution = host.system_info.distribution
+    if distribution == "amzn":
+        pkgs = ["tigervnc-server"]
+    elif distribution == "debian" or distribution == "kali":
+        pkgs = ["tigervnc-standalone-server", "tigervnc-common"]
+    else:
+        # We don't support this distribution
+        assert False
+    packages = [host.package(pkg) for pkg in pkgs]
+    installed = [package.is_installed for package in packages]
+    assert len(pkgs) != 0
+    assert all(installed)

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,7 +4,6 @@
 import os
 
 # Third-Party Libraries
-import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,38 @@
     dest: /lib/systemd/system/
     mode: 0644
 
+# Guacamole prefers to connect to the VNC server with TLSVnc security,
+# however that resulted in frequent disconnections of the VNC session
+# with errors like the following (from /home/vnc/.vnc/ip-*:1.log):
+#    Connections: closed: 10.10.50.20::53496
+#                 (readTLS: (unknown error code) (384))
+#     TLS:         TLS session wasn't terminated gracefully
+# The root cause may be:
+# https://issues.apache.org/jira/browse/GUACAMOLE-414 However, the fix
+# for that issue has not yet made it's way to the official Guacamole
+# docker image, which is what we use.  Until that happens, our
+# workaround is to force the VNC server to not accept authentication
+# via TLS ("TLSVnc"), and only accept "VncAuth".  This is accomplished
+# by adding "-SecurityType VncAuth" as a startup parameter to
+# vncserver in the systemd service file.
+#
+# Reminder to get rid of this in the future:
+#   https://github.com/cisagov/pca-gophish-composition-packer/issues/2
+- name: Remove SecurityTypes (if any) from VNC systemd service file
+  replace:
+    path: /lib/systemd/system/vncserver@.service
+    regexp: "(^ExecStart=.*)-SecurityTypes[ ][\\w, ]+(.*)"
+    replace: \1\2
+
+- name: Add SecurityTypes VncAuth to VNC systemd service file
+  replace:
+    path: /lib/systemd/system/vncserver@.service
+    regexp: "(^ExecStart=.*)"
+    replace: \1 -SecurityTypes VncAuth
+#
+# End Guacamole TLS foo
+#
+
 - name: Systemd daemon-reload
   systemd:
     daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,38 +61,6 @@
     dest: /lib/systemd/system/
     mode: 0644
 
-# Guacamole prefers to connect to the VNC server with TLSVnc security,
-# however that resulted in frequent disconnections of the VNC session
-# with errors like the following (from /home/vnc/.vnc/ip-*:1.log):
-#    Connections: closed: 10.10.50.20::53496
-#                 (readTLS: (unknown error code) (384))
-#     TLS:         TLS session wasn't terminated gracefully
-# The root cause may be:
-# https://issues.apache.org/jira/browse/GUACAMOLE-414 However, the fix
-# for that issue has not yet made it's way to the official Guacamole
-# docker image, which is what we use.  Until that happens, our
-# workaround is to force the VNC server to not accept authentication
-# via TLS ("TLSVnc"), and only accept "VncAuth".  This is accomplished
-# by adding "-SecurityType VncAuth" as a startup parameter to
-# vncserver in the systemd service file.
-#
-# Reminder to get rid of this in the future:
-#   https://github.com/cisagov/pca-gophish-composition-packer/issues/2
-- name: Remove SecurityTypes (if any) from VNC systemd service file
-  replace:
-    path: /lib/systemd/system/vncserver@.service
-    regexp: "(^ExecStart=.*)-SecurityTypes[ ][\\w, ]+(.*)"
-    replace: \1\2
-
-- name: Add SecurityTypes VncAuth to VNC systemd service file
-  replace:
-    path: /lib/systemd/system/vncserver@.service
-    regexp: "(^ExecStart=.*)"
-    replace: \1 -SecurityTypes VncAuth
-#
-# End Guacamole TLS foo
-#
-
 - name: Systemd daemon-reload
   systemd:
     daemon_reload: true

--- a/templates/vncserver@.service
+++ b/templates/vncserver@.service
@@ -49,7 +49,7 @@ ExecStartPre=/bin/sh -c "/usr/bin/vncserver -kill :%i > /dev/null 2>&1 || :"
 #   authentication.
 #
 # Reminder to get rid of this in the future:
-#   https://github.com/cisagov/ansible-role-vnc-server/issues/2
+#   https://github.com/cisagov/ansible-role-vnc-server/issues/5
 ExecStart=/usr/bin/vncserver :%i -localhost no -alwaysshared -fg -geometry 1920x1080 -SecurityTypes VncAuth
 ExecStop=/usr/bin/vncserver -kill :%i
 

--- a/templates/vncserver@.service
+++ b/templates/vncserver@.service
@@ -7,23 +7,49 @@ Type=simple
 User={{ username }}
 PIDFile=/home/{{ username }}/.vnc/%H%i.pid
 ExecStartPre=/bin/sh -c "/usr/bin/vncserver -kill :%i > /dev/null 2>&1 || :"
-# Guacamole prefers to connect to the VNC server with TLSVnc security,
-# however that resulted in frequent disconnections of the VNC session
-# with errors like the following (from /home/vnc/.vnc/ip-*:1.log):
-#    Connections: closed: 10.10.50.20::53496
-#                 (readTLS: (unknown error code) (384))
-#     TLS:         TLS session wasn't terminated gracefully
-# The root cause may be:
-# https://issues.apache.org/jira/browse/GUACAMOLE-414 However, the fix
-# for that issue has not yet made it's way to the official Guacamole
-# docker image, which is what we use.  Until that happens, our
-# workaround is to force the VNC server to not accept authentication
-# via TLS ("TLSVnc"), and only accept "VncAuth".  This is accomplished
-# by adding "-SecurityType VncAuth" as a startup parameter to
-# vncserver in the systemd service file.
+# We are currently testing the latest 1.1.0 Guacamole images
+# (guacamole and guacd), and we are still seeing sporadic VNC
+# disconnections by Guacamole (as described in
+# https://github.com/cisagov/pca-gophish-composition-packer/pull/#1)
+# when we do not start the VNC server with -SecurityType VncAuth (to
+# disable the TLSVnc authentication).
+#
+# In the Guacamole PR with the potential fix for this issue, they state:
+#
+# Note that support for these callbacks was released in
+# LibVNCServer/Client 0.9.11, so it will only work against 0.9.11 or
+# later - the bug documented in GUACAMOLE-414 will still be present
+# when using libvncserver/client prior to 0.9.11.
+#
+# We should be fine on that front, since our VNC server host is
+# running with libvncserver version 0.9.12:
+#
+# dpkg -l | grep libvncserver
+# ii  libvncserver1:amd64  0.9.12+dfsg-8  amd64  API to write one's own VNC server
+#
+# Note that the error message in the VNC server is slightly different now:
+#
+# VNCSConnST:  closing 10.224.1.13::60288: readTLS: Decryption has failed. (-24)
+# ...
+# TLS:         TLS session wasn't terminated gracefully
+#
+# Here is what it looks like in the guacd Docker container log:
+#
+# guacd | guacd[567]: ERROR:	Error handling message from VNC server.
+# guacd | guacd[567]: INFO:	Internal VNC client disconnected
+#
+# I see two possibilities:
+#
+# * Fairly unlikely: The Guacamole fix that was made back in April
+#   2019 has not made its way into the Docker image created on
+#   Jan. 29, 2020.
+# * More likely: There is an additional issue going on here that we
+#   are not aware of.
+# * For now, we will continue to run without using TLSVnc
+#   authentication.
 #
 # Reminder to get rid of this in the future:
-#   https://github.com/cisagov/pca-gophish-composition-packer/issues/2
+#   https://github.com/cisagov/ansible-role-vnc-server/issues/2
 ExecStart=/usr/bin/vncserver :%i -localhost no -alwaysshared -fg -geometry 1920x1080 -SecurityTypes VncAuth
 ExecStop=/usr/bin/vncserver -kill :%i
 

--- a/templates/vncserver@.service
+++ b/templates/vncserver@.service
@@ -7,7 +7,24 @@ Type=simple
 User={{ username }}
 PIDFile=/home/{{ username }}/.vnc/%H%i.pid
 ExecStartPre=/bin/sh -c "/usr/bin/vncserver -kill :%i > /dev/null 2>&1 || :"
-ExecStart=/usr/bin/vncserver :%i -localhost no -alwaysshared -fg -geometry 1920x1080
+# Guacamole prefers to connect to the VNC server with TLSVnc security,
+# however that resulted in frequent disconnections of the VNC session
+# with errors like the following (from /home/vnc/.vnc/ip-*:1.log):
+#    Connections: closed: 10.10.50.20::53496
+#                 (readTLS: (unknown error code) (384))
+#     TLS:         TLS session wasn't terminated gracefully
+# The root cause may be:
+# https://issues.apache.org/jira/browse/GUACAMOLE-414 However, the fix
+# for that issue has not yet made it's way to the official Guacamole
+# docker image, which is what we use.  Until that happens, our
+# workaround is to force the VNC server to not accept authentication
+# via TLS ("TLSVnc"), and only accept "VncAuth".  This is accomplished
+# by adding "-SecurityType VncAuth" as a startup parameter to
+# vncserver in the systemd service file.
+#
+# Reminder to get rid of this in the future:
+#   https://github.com/cisagov/pca-gophish-composition-packer/issues/2
+ExecStart=/usr/bin/vncserver :%i -localhost no -alwaysshared -fg -geometry 1920x1080 -SecurityTypes VncAuth
 ExecStop=/usr/bin/vncserver -kill :%i
 
 [Install]


### PR DESCRIPTION
## 🗣 Description

This pull request makes the following changes:
* Use the systemd-enabled Kali Docker image, now that we have one
* Add [the anti-disconnect foo/jazz from cisagov/pca-gophish-composition-packer](https://github.com/cisagov/pca-gophish-composition-packer/blob/develop/src/playbook.yml#L22-L75)

## 💭 Motivation and Context

When we were testing VNC via the Guacamole server in ENV0, we found that the connections were still being randomly disconnected if we didn't include these fixes.

## 🧪 Testing

These changes have been tested in the COOL in ENV0.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
