### PR TITLE
Add ssh key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,7 @@
 username: vnc
 # Generate a random VNC password and save it to /tmp
 password: "{{ lookup('password', '/tmp/vnc_password.txt') }}"
+# Public ssh key for VNC user
+public_ssh_key: ""
+# Private ssh key for VNC user
+private_ssh_key: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,8 @@
 # Install an SSH keypair for the VNC user.  This will enable Guacamole
 # to perform file transfers to/from this instance.
 #
-# Note that Guacamole currently only supports RSA keys.
+# Note that Guacamole (guacd, as of v.1.1.0) currently only supports
+# RSA keys.
 #
 - name: Install SSH public key for VNC user
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,31 +61,31 @@
 # Install an SSH keypair for the VNC user.  This will enable Guacamole
 # to perform file transfers to/from this instance.
 #
-# Note that Guacamole (v.1.0.0) currently only supports RSA keys.
+# Note that Guacamole currently only supports RSA keys.
 #
 - name: Install SSH public key for VNC user
   copy:
-    content: "{{ vnc_ssh_public_key }}"
-    dest: "/home/{{ vnc_username }}/.ssh/id_rsa.pub"
+    content: "{{ public_ssh_key }}"
+    dest: "/home/{{ username }}/.ssh/id_rsa.pub"
     mode: 0644
-    owner: "{{ vnc_username }}"
-    group: "{{ vnc_username }}"
+    owner: "{{ username }}"
+    group: "{{ username }}"
   when: public_ssh_key|length > 0
 
 - name: Install SSH private key for VNC user
   copy:
-    content: "{{ vnc_ssh_private_key }}"
-    dest: "/home/{{ vnc_username }}/.ssh/id_rsa"
+    content: "{{ private_ssh_key }}"
+    dest: "/home/{{ username }}/.ssh/id_rsa"
     mode: 0600
-    owner: "{{ vnc_username }}"
-    group: "{{ vnc_username }}"
+    owner: "{{ username }}"
+    group: "{{ username }}"
   no_log: true
   when: private_ssh_key|length > 0
 
 - name: Add VNC SSH public key as authorized key
   authorized_key:
-    user: "{{ vnc_username }}"
-    key: "{{ vnc_ssh_public_key }}"
+    user: "{{ username }}"
+    key: "{{ public_ssh_key }}"
   when:
     - public_ssh_key|length > 0
     - private_ssh_key|length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
 # tasks file for ansible-role-vnc-server
 
-- name: Create the VNC user
-  user:
-    name: "{{ username }}"
-    shell: /bin/bash
-
 - name: Load var file with package names based on the OS type
   include_vars: "{{ lookup('first_found', params) }}"
   vars:
@@ -30,6 +25,14 @@
   file:
     path: /etc/xdg/autostart/light-locker.desktop
     state: absent
+
+#
+# Create and configure the vnc user
+#
+- name: Create the VNC user
+  user:
+    name: "{{ username }}"
+    shell: /bin/bash
 
 - name: Create .vnc directory for VNC user
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,8 +23,7 @@
 
 - name: Install TigerVNC server
   package:
-    name:
-      "{{ package_names }}"
+    name: "{{ vnc_package_names }}"
 
 # Does this go here?  Can this be generalized?
 - name: Disable screen locking

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,6 +57,42 @@
     group: "{{ username }}"
     mode: 0600
 
+#
+# Install an SSH keypair for the VNC user.  This will enable Guacamole
+# to perform file transfers to/from this instance.
+#
+# Note that Guacamole (v.1.0.0) currently only supports RSA keys.
+#
+- name: Install SSH public key for VNC user
+  copy:
+    content: "{{ vnc_ssh_public_key }}"
+    dest: "/home/{{ vnc_username }}/.ssh/id_rsa.pub"
+    mode: 0644
+    owner: "{{ vnc_username }}"
+    group: "{{ vnc_username }}"
+  when: public_ssh_key|length > 0
+
+- name: Install SSH private key for VNC user
+  copy:
+    content: "{{ vnc_ssh_private_key }}"
+    dest: "/home/{{ vnc_username }}/.ssh/id_rsa"
+    mode: 0600
+    owner: "{{ vnc_username }}"
+    group: "{{ vnc_username }}"
+  no_log: true
+  when: private_ssh_key|length > 0
+
+- name: Add VNC SSH public key as authorized key
+  authorized_key:
+    user: "{{ vnc_username }}"
+    key: "{{ vnc_ssh_public_key }}"
+  when:
+    - public_ssh_key|length > 0
+    - private_ssh_key|length > 0
+
+#
+# Set up VNC systemd service
+#
 - name: Set up VNC as a systemd service
   template:
     src: vncserver@.service

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -2,5 +2,5 @@
 # vars file for Amazon Linux
 
 # The TigerVNC package names
-package_names:
+vnc_package_names:
   - tigervnc-server

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,6 @@
 # vars file for Debian
 
 # The TigerVNC package names
-package_names:
+vnc_package_names:
   - tigervnc-standalone-server
   - tigervnc-common

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,5 +2,5 @@
 # vars file for RedHat
 
 # The TigerVNC package names
-package_names:
+vnc_package_names:
   - tigervnc-server


### PR DESCRIPTION
## 🗣 Description

This PR:
* Fixes a bug due to other Ansible roles polluting the variable space and causing incorrect packages to be installed
* Adds code to install public and private ssh keys for the VNC user, if desired

## 💭 Motivation and Context

We need the correct packages to be installed, and we need to be able to transfer files to and from the Kali instance via sftp.

## 🧪 Testing

All the pre-commit hooks and the molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
