### PR TITLE
Create the .ssh directory for the VNC user if necessary

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,14 @@
 # Note that Guacamole (guacd, as of v.1.1.0) currently only supports
 # RSA keys.
 #
+- name: Create .ssh directory for VNC user
+  file:
+    path: "/home/{{ username }}/.ssh"
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: 0755
+
 - name: Install SSH public key for VNC user
   copy:
     content: "{{ public_ssh_key }}"


### PR DESCRIPTION
## 🗣 Description

Create the `.ssh` directory for the VNC user if necessary.

## 💭 Motivation and Context

I got an error copying ssh keys to a directory that didn't exist.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
