### PR TITLE
Add Kali-specific tasks to work around a bug in TigerVNC

### DIFF
--- a/tasks/configure_systemd.yml
+++ b/tasks/configure_systemd.yml
@@ -1,0 +1,19 @@
+---
+- name: Set up VNC as a systemd service
+  ansible.builtin.template:
+    src: vncserver@.service
+    dest: /lib/systemd/system/
+    mode: 0644
+
+- name: Systemd daemon-reload
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when:
+    - ansible_service_mgr == "systemd"
+
+- name: Enable VNC systemd service
+  ansible.builtin.systemd:
+    name: "vncserver@1.service"
+    enabled: true
+  when:
+    - ansible_service_mgr == "systemd"

--- a/tasks/configure_systemd.yml
+++ b/tasks/configure_systemd.yml
@@ -8,12 +8,8 @@
 - name: Systemd daemon-reload
   ansible.builtin.systemd:
     daemon_reload: true
-  when:
-    - ansible_service_mgr == "systemd"
 
 - name: Enable VNC systemd service
   ansible.builtin.systemd:
     name: "vncserver@1.service"
     enabled: true
-  when:
-    - ansible_service_mgr == "systemd"

--- a/tasks/create_vnc_user.yml
+++ b/tasks/create_vnc_user.yml
@@ -1,0 +1,73 @@
+---
+#
+# Create and configure the vnc user
+#
+- name: Create the VNC user
+  ansible.builtin.user:
+    name: "{{ username }}"
+    shell: /bin/bash
+
+- name: Create .vnc directory for VNC user
+  ansible.builtin.file:
+    path: /home/{{ username }}/.vnc
+    state: directory
+    mode: 0755
+    owner: "{{ username }}"
+    group: "{{ username }}"
+
+- name: Set VNC password for VNC user
+  ansible.builtin.shell: |
+    set -o pipefail
+    echo {{ password }} | vncpasswd -f > /home/{{ username }}/.vnc/passwd
+  args:
+    executable: /bin/bash
+    creates: /home/{{ username }}/.vnc/passwd
+
+- name: Set correct permissions for VNC passwd file
+  ansible.builtin.file:
+    path: /home/{{ username }}/.vnc/passwd
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: 0600
+
+#
+# Install an SSH keypair for the VNC user.  This will enable Guacamole
+# to perform file transfers to/from this instance.
+#
+# Note that Guacamole (guacd, as of v.1.1.0) currently only supports
+# RSA keys.
+#
+- name: Create .ssh directory for VNC user
+  ansible.builtin.file:
+    path: "/home/{{ username }}/.ssh"
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: 0755
+
+- name: Install SSH public key for VNC user
+  ansible.builtin.copy:
+    content: "{{ public_ssh_key }}"
+    dest: "/home/{{ username }}/.ssh/id_rsa.pub"
+    mode: 0644
+    owner: "{{ username }}"
+    group: "{{ username }}"
+  when: public_ssh_key|length > 0
+
+- name: Install SSH private key for VNC user
+  ansible.builtin.copy:
+    content: "{{ private_ssh_key }}"
+    dest: "/home/{{ username }}/.ssh/id_rsa"
+    mode: 0600
+    owner: "{{ username }}"
+    group: "{{ username }}"
+  no_log: true
+  when: private_ssh_key|length > 0
+
+- name: Add VNC SSH public key as authorized key
+  ansible.builtin.authorized_key:
+    user: "{{ username }}"
+    key: "{{ public_ssh_key }}"
+  when:
+    - public_ssh_key|length > 0
+    - private_ssh_key|length > 0

--- a/tasks/create_vnc_user.yml
+++ b/tasks/create_vnc_user.yml
@@ -34,8 +34,9 @@
 # Install an SSH keypair for the VNC user.  This will enable Guacamole
 # to perform file transfers to/from this instance.
 #
-# Note that Guacamole (guacd, as of v.1.1.0) currently only supports
-# RSA keys.
+# Note that Guacamole (guacd, as of v.1.3.0) currently only supports
+# RSA and DSA keys.
+# See https://github.com/apache/guacamole-server/blob/b2ae2fdf003a6854ac42877ce0fce8e88ceb038a/src/common-ssh/key.c#L52-L141
 #
 - name: Create .ssh directory for VNC user
   ansible.builtin.file:

--- a/tasks/disable_screen_locking.yml
+++ b/tasks/disable_screen_locking.yml
@@ -1,0 +1,6 @@
+---
+# Should this live inside this role?  Can this be generalized?
+- name: Disable screen locking
+  ansible.builtin.file:
+    path: /etc/xdg/autostart/light-locker.desktop
+    state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,4 @@
+---
+- name: Install TigerVNC server
+  ansible.builtin.package:
+    name: "{{ vnc_package_names }}"

--- a/tasks/install_Kali.yml
+++ b/tasks/install_Kali.yml
@@ -1,0 +1,13 @@
+---
+# TODO: This entire file should be removed once version 1.11.0+dfsg-2
+# of tigervnc-standalone-server becomes available in Debian Testing.
+#
+# See cisagov/ansible-role-vnc-server#15 for more details.
+- name: Install TigerVNC server
+  block:
+    - name: Install tigervnc-common
+      ansible.builtin.apt:
+        deb: http://snapshot.debian.org/archive/debian/20200929T025235Z/pool/main/t/tigervnc/tigervnc-common_1.10.1%2Bdfsg-9_amd64.deb
+    - name: Install tigervnc-standalone-server
+      ansible.builtin.apt:
+        deb:  http://snapshot.debian.org/archive/debian/20200929T025235Z/pool/main/t/tigervnc/tigervnc-standalone-server_1.10.1%2Bdfsg-9_amd64.deb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,20 @@
         - "{{ role_path }}/vars"
 
 - name: Install VNC server
-  ansible.builtin.include_tasks: install.yml
+  # TODO: This dynamic jazz can be removed once version 1.11.0+dfsg-2
+  # of tigervnc-standalone-server becomes available in Debian Testing.
+  #
+  # See cisagov/ansible-role-vnc-server#15 for more details.
+  ansible.builtin.include_tasks: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - install_{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml
+        - install_{{ ansible_distribution }}.yml
+        - install_{{ ansible_os_family }}.yml
+        - install.yml
+      paths:
+        - "{{ role_path }}/tasks"
 
 - name: Disable screen locking
   ansible.builtin.include_tasks: disable_screen_locking.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,107 +10,14 @@
       paths:
         - "{{ role_path }}/vars"
 
-- name: Install TigerVNC server
-  ansible.builtin.package:
-    name: "{{ vnc_package_names }}"
+- name: Install VNC server
+  ansible.builtin.include_tasks: install.yml
 
-# Does this go here?  Can this be generalized?
 - name: Disable screen locking
-  ansible.builtin.file:
-    path: /etc/xdg/autostart/light-locker.desktop
-    state: absent
+  ansible.builtin.include_tasks: disable_screen_locking.yml
 
-#
-# Create and configure the vnc user
-#
-- name: Create the VNC user
-  ansible.builtin.user:
-    name: "{{ username }}"
-    shell: /bin/bash
+- name: Create vnc user
+  ansible.builtin.include_tasks: create_vnc_user.yml
 
-- name: Create .vnc directory for VNC user
-  ansible.builtin.file:
-    path: /home/{{ username }}/.vnc
-    state: directory
-    mode: 0755
-    owner: "{{ username }}"
-    group: "{{ username }}"
-
-- name: Set VNC password for VNC user
-  ansible.builtin.shell: |
-    set -o pipefail
-    echo {{ password }} | vncpasswd -f > /home/{{ username }}/.vnc/passwd
-  args:
-    executable: /bin/bash
-    creates: /home/{{ username }}/.vnc/passwd
-
-- name: Set correct permissions for VNC passwd file
-  ansible.builtin.file:
-    path: /home/{{ username }}/.vnc/passwd
-    owner: "{{ username }}"
-    group: "{{ username }}"
-    mode: 0600
-
-#
-# Install an SSH keypair for the VNC user.  This will enable Guacamole
-# to perform file transfers to/from this instance.
-#
-# Note that Guacamole (guacd, as of v.1.1.0) currently only supports
-# RSA keys.
-#
-- name: Create .ssh directory for VNC user
-  ansible.builtin.file:
-    path: "/home/{{ username }}/.ssh"
-    state: directory
-    owner: "{{ username }}"
-    group: "{{ username }}"
-    mode: 0755
-
-- name: Install SSH public key for VNC user
-  ansible.builtin.copy:
-    content: "{{ public_ssh_key }}"
-    dest: "/home/{{ username }}/.ssh/id_rsa.pub"
-    mode: 0644
-    owner: "{{ username }}"
-    group: "{{ username }}"
-  when: public_ssh_key|length > 0
-
-- name: Install SSH private key for VNC user
-  ansible.builtin.copy:
-    content: "{{ private_ssh_key }}"
-    dest: "/home/{{ username }}/.ssh/id_rsa"
-    mode: 0600
-    owner: "{{ username }}"
-    group: "{{ username }}"
-  no_log: true
-  when: private_ssh_key|length > 0
-
-- name: Add VNC SSH public key as authorized key
-  ansible.builtin.authorized_key:
-    user: "{{ username }}"
-    key: "{{ public_ssh_key }}"
-  when:
-    - public_ssh_key|length > 0
-    - private_ssh_key|length > 0
-
-#
-# Set up VNC systemd service
-#
-- name: Set up VNC as a systemd service
-  ansible.builtin.template:
-    src: vncserver@.service
-    dest: /lib/systemd/system/
-    mode: 0644
-
-- name: Systemd daemon-reload
-  ansible.builtin.systemd:
-    daemon_reload: true
-  when:
-    - ansible_service_mgr == "systemd"
-
-- name: Enable VNC systemd service
-  ansible.builtin.systemd:
-    name: "vncserver@1.service"
-    enabled: true
-  when:
-    - ansible_service_mgr == "systemd"
+- name: Configure SystemD
+  ansible.builtin.include_tasks: configure_systemd.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,26 +1,22 @@
 ---
-# tasks file for ansible-role-vnc-server
-
 - name: Load var file with package names based on the OS type
-  include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
-        # Add regex_replace() filters to remove spaces and
-        # slashes. This allows the OS family/distribution for Kali,
-        # "Kali GNU/Linux", to be easily mapped to a vars file.
-        - "{{ ansible_distribution | regex_replace('[ /]', '_') }}.yml"
-        - "{{ ansible_os_family | regex_replace('[ /]', '_') }}.yml"
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
       paths:
         - "{{ role_path }}/vars"
 
 - name: Install TigerVNC server
-  package:
+  ansible.builtin.package:
     name: "{{ vnc_package_names }}"
 
 # Does this go here?  Can this be generalized?
 - name: Disable screen locking
-  file:
+  ansible.builtin.file:
     path: /etc/xdg/autostart/light-locker.desktop
     state: absent
 
@@ -28,12 +24,12 @@
 # Create and configure the vnc user
 #
 - name: Create the VNC user
-  user:
+  ansible.builtin.user:
     name: "{{ username }}"
     shell: /bin/bash
 
 - name: Create .vnc directory for VNC user
-  file:
+  ansible.builtin.file:
     path: /home/{{ username }}/.vnc
     state: directory
     mode: 0755
@@ -41,7 +37,7 @@
     group: "{{ username }}"
 
 - name: Set VNC password for VNC user
-  shell: |
+  ansible.builtin.shell: |
     set -o pipefail
     echo {{ password }} | vncpasswd -f > /home/{{ username }}/.vnc/passwd
   args:
@@ -49,7 +45,7 @@
     creates: /home/{{ username }}/.vnc/passwd
 
 - name: Set correct permissions for VNC passwd file
-  file:
+  ansible.builtin.file:
     path: /home/{{ username }}/.vnc/passwd
     owner: "{{ username }}"
     group: "{{ username }}"
@@ -63,7 +59,7 @@
 # RSA keys.
 #
 - name: Create .ssh directory for VNC user
-  file:
+  ansible.builtin.file:
     path: "/home/{{ username }}/.ssh"
     state: directory
     owner: "{{ username }}"
@@ -71,7 +67,7 @@
     mode: 0755
 
 - name: Install SSH public key for VNC user
-  copy:
+  ansible.builtin.copy:
     content: "{{ public_ssh_key }}"
     dest: "/home/{{ username }}/.ssh/id_rsa.pub"
     mode: 0644
@@ -80,7 +76,7 @@
   when: public_ssh_key|length > 0
 
 - name: Install SSH private key for VNC user
-  copy:
+  ansible.builtin.copy:
     content: "{{ private_ssh_key }}"
     dest: "/home/{{ username }}/.ssh/id_rsa"
     mode: 0600
@@ -90,7 +86,7 @@
   when: private_ssh_key|length > 0
 
 - name: Add VNC SSH public key as authorized key
-  authorized_key:
+  ansible.builtin.authorized_key:
     user: "{{ username }}"
     key: "{{ public_ssh_key }}"
   when:
@@ -101,19 +97,19 @@
 # Set up VNC systemd service
 #
 - name: Set up VNC as a systemd service
-  template:
+  ansible.builtin.template:
     src: vncserver@.service
     dest: /lib/systemd/system/
     mode: 0644
 
 - name: Systemd daemon-reload
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: true
   when:
     - ansible_service_mgr == "systemd"
 
 - name: Enable VNC systemd service
-  systemd:
+  ansible.builtin.systemd:
     name: "vncserver@1.service"
     enabled: true
   when:


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
* Adds some Kali-specific tasks to work around a bug in the the Debian Testing `tigervnc-standalone-server` package.
* Makes a few changes to slightly modernize this Ansible role.

The Kali-specific changes should be reverted once `tigervnc-standalone-server` version `1.11.0+dfsg-2` becomes available for Debian Testing (codenamed bullseye).  I created #15 as a reminder to do this.

## 💭 Motivation and context ##

Resolves cisagov/cool-system#183.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  I also built a new Kali AMI with these changes and deployed it to our staging COOL environment to verify that these changes work as expected.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
