### PR TITLE
Modify unit file to automatically restart the service on failure

### DIFF
--- a/tasks/configure_systemd.yml
+++ b/tasks/configure_systemd.yml
@@ -4,7 +4,7 @@
     src: vncserver@.service
     dest: /lib/systemd/system/
     mode: 0644
-    validate: /usr/bin/systemd-analyze validate %s
+    validate: /usr/bin/systemd-analyze verify %s
 
 - name: Systemd daemon-reload
   ansible.builtin.systemd:

--- a/tasks/configure_systemd.yml
+++ b/tasks/configure_systemd.yml
@@ -4,7 +4,10 @@
     src: vncserver@.service
     dest: /lib/systemd/system/
     mode: 0644
-    validate: /usr/bin/systemd-analyze verify %s
+    # It would be great to use systemd-analyze verify here, but that
+    # won't work.  See, for instance, this GitHub issue comment:
+    # https://github.com/ansible/ansible/issues/19243#issuecomment-266508074
+    # validate: /usr/bin/systemd-analyze verify %s
 
 - name: Systemd daemon-reload
   ansible.builtin.systemd:

--- a/tasks/configure_systemd.yml
+++ b/tasks/configure_systemd.yml
@@ -4,6 +4,7 @@
     src: vncserver@.service
     dest: /lib/systemd/system/
     mode: 0644
+    validate: /usr/bin/systemd-analyze validate %s
 
 - name: Systemd daemon-reload
   ansible.builtin.systemd:

--- a/templates/vncserver@.service
+++ b/templates/vncserver@.service
@@ -52,6 +52,13 @@ ExecStartPre=/bin/sh -c "/usr/bin/vncserver -kill :%i > /dev/null 2>&1 || :"
 #   https://github.com/cisagov/ansible-role-vnc-server/issues/5
 ExecStart=/usr/bin/vncserver :%i -localhost no -alwaysshared -fg -geometry 1920x1080 -SecurityTypes VncAuth
 ExecStop=/usr/bin/vncserver -kill :%i
+# Sometimes BurpSuitePro runs out of memory and is killed by the
+# kernel, bringing down this service in the process.  This doesn't fix
+# that issue, but it does automatically restart the service so that
+# the assessors can continue on without asking dev folks to intervene.
+Restart=on-failure
+# Wait a few seconds to let the dust settle before restarting.
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/vncserver@.service
+++ b/templates/vncserver@.service
@@ -58,7 +58,7 @@ ExecStop=/usr/bin/vncserver -kill :%i
 # Sometimes BurpSuitePro runs out of memory and is killed by the
 # kernel, bringing down this service in the process.  This doesn't fix
 # that issue, but it does automatically restart the service so that
-# the assessors can continue on without asking dev folks to intervene.
+# the assessors can continue on without needing anyone else to intervene.
 Restart=on-failure
 # Wait a few seconds to let the dust settle before restarting.
 RestartSec=5s

--- a/templates/vncserver@.service
+++ b/templates/vncserver@.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Remote desktop service (VNC)
 After=syslog.target network.target
+# If we try to restart five times in 30 seconds, just give up.
+StartLimitIntervalSec=30s
+StartLimitBurst=5
 
 [Service]
 Type=simple


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the unit file for `vncserver@1.service` so that the service is automatically restarted when the service fails.

## 💭 Motivation and context ##

Sometimes BurpSuitePro runs out of memory and is killed by the kernel, bringing down this service in the process.  This change doesn't fix that issue, but it does automatically restart the service so that the users can continue on without asking dev folks to intervene.

Closes #19.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  I also created a new Kali AMI for staging with these changes and verified that it functioned as expected:  see cisagov/kali-packer#66 for more details.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
