### PR TITLE
Add ability to specify the VNC user's UID and additional groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ None.
 | private\_ssh\_key | The private ssh key for the VNC user. | By default no such key is assigned to the VNC user. | No |
 | public\_ssh\_key | The public ssh key for the VNC user. | By default no such key is assigned to the VNC user. | No |
 | username | The name of the VNC user, which will be created. | `vnc` | No |
+| user_groups | A list of additional groups to which the VNC user should belong. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
+| user_uid | The UID to use for the VNC user. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ None.
 | private\_ssh\_key | The private ssh key for the VNC user. | By default no such key is assigned to the VNC user. | No |
 | public\_ssh\_key | The public ssh key for the VNC user. | By default no such key is assigned to the VNC user. | No |
 | username | The name of the VNC user, which will be created. | `vnc` | No |
-| user_groups | A list of additional groups to which the VNC user should belong. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
-| user_uid | The UID to use for the VNC user. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
+| user\_groups | A list of additional groups to which the VNC user should belong. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
+| user\_uid | The UID to use for the VNC user. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 
 ## Dependencies ##
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
   # Kali Linux, so it makes sense to force the installation of Ansible
   # 2.10 or newer.
   min_ansible_version: 2.10
+  namespace: cisagov
   platforms:
     - name: Amazon
       versions:

--- a/tasks/create_vnc_user.yml
+++ b/tasks/create_vnc_user.yml
@@ -4,8 +4,11 @@
 #
 - name: Create the VNC user
   ansible.builtin.user:
+    append: yes
+    groups: "{{ user_groups | default(omit) }}"
     name: "{{ username }}"
     shell: /bin/bash
+    uid: "{{ user_uid | default(omit) }}"
 
 - name: Create .vnc directory for VNC user
   ansible.builtin.file:


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the ability to specify the VNC user's UID and additional groups.

## 💭 Motivation and context ##

This is useful because in some cisagov/*-packer repositories we want the `vnc` user to be assigned to the `efs_users` group created in cisagov/ansible-role-amazon-efs-utils#24.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
