### PR TITLE
Remove collections from meta/requirements.yml

### DIFF
--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -9,9 +9,4 @@
 # both sets of dependencies must be lists. :(
 #
 # See also cisagov/skeleton-ansible-role#153.
-collections:
-  - name: ansible.posix
-    type: galaxy
-    # We require ansible.posix.authorized_keys, which debuted in
-    # version 1.0.0 of ansible.posix.
-    version: ">=1.0.0"
+[]


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes any collections from `meta/requirements.yml`.

## 💭 Motivation and context ##

`ansible-galaxy` does not appear to allow collections to appear in the `meta/requirements.yml` file.  See [here](https://github.com/cisagov/skeleton-ansible-role/issues/153#issuecomment-1785671824) for more details.

See also cisagov/skeleton-ansible-role#165.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.