### PR TITLE
Correctly disable screen locking and disable DPMS on XFCE4

### DIFF
--- a/files/light-locker.desktop
+++ b/files/light-locker.desktop
@@ -1,0 +1,7 @@
+# This desktop entry file overrides the default present in
+# /etc/xdg/autostart, if it exists.  This way the light-locker screen
+# locker is not started.
+[Desktop Entry]
+Hidden=true
+Name=Screen Locker
+Type=Application

--- a/files/xfce4-power-manager-disable-dpms.desktop
+++ b/files/xfce4-power-manager-disable-dpms.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Exec=xfconf-query --channel xfce4-power-manager --create --property /xfce4-power-manager/dpms-enabled --set false --type bool
+Name=Disable xfce4-power-manager DPMS
+Type=Application

--- a/files/xfce4-screensaver-disable-screen-locking.desktop
+++ b/files/xfce4-screensaver-disable-screen-locking.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Exec=xfconf-query --channel xfce4-screensaver --create --property /lock/enabled --set false --type bool
+Name=Disable xfce4-screensaver screen locking
+Type=Application

--- a/files/xfce4-screensaver-disable.desktop
+++ b/files/xfce4-screensaver-disable.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Exec=xfconf-query --channel xfce4-screensaver --create --property /saver/enabled --set false --type bool
+Name=Disable xfce4-screensaver
+Type=Application

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -38,5 +38,9 @@ def test_packages(host):
     ],
 )
 def test_autostart_files_exist(host, f):
-    """Test that the file exists."""
+    """Test that the file exists and has the expected ownership and permissions."""
     assert host.file(f).exists
+    assert host.file(f).is_file
+    assert host.file(f).user == "vnc"
+    assert host.file(f).group == "vnc"
+    assert host.file(f).mode == 0o644

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -59,7 +59,14 @@ def test_autostart_files_exist(host, f):
 def test_systemd_service_enabled(host):
     """Test that the VNC systemd service is valid and enabled."""
     service = host.service("vncserver@1")
-    assert service.is_valid
+    # TODO: Something funky happens on Ubuntu 22.04.  is_valid is false for
+    # reasons unrelated to the systemd service we put in place.  See #57 for
+    # more details.
+    if (
+        host.system_info.distribution != "ubuntu"
+        or host.system_info.codename != "jammy"
+    ):
+        assert service.is_valid
     assert service.is_enabled
     assert not service.is_masked
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -31,6 +31,7 @@ def test_packages(host):
 @pytest.mark.parametrize(
     "f",
     [
+        "/home/vnc/.config/autostart/light-locker.desktop",
         "/home/vnc/.config/autostart/xfce4-power-manager-disable-dpms.desktop",
         "/home/vnc/.config/autostart/xfce4-screensaver-disable.desktop",
         "/home/vnc/.config/autostart/xfce4-screensaver-disable-screen-locking.desktop",

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -28,6 +28,16 @@ def test_packages(host):
     assert all(installed)
 
 
+def test_autostart_dir_exists(host):
+    """Test that the directory exists and has the expected ownership and permissions."""
+    f = host.file("/home/vnc/.config/autostart")
+    assert f.exists
+    assert f.is_directory
+    assert f.user == "vnc"
+    assert f.group == "vnc"
+    assert f.mode == 0o755
+
+
 @pytest.mark.parametrize(
     "f",
     [

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -62,3 +62,37 @@ def test_systemd_service_enabled(host):
     assert service.is_valid
     assert service.is_enabled
     assert not service.is_masked
+
+
+def test_vnc_user(host):
+    """Test that the VNC user was created."""
+    user = host.user("vnc")
+    assert user.exists
+    assert user.shell == "/bin/bash"
+
+
+def test_vnc_user_config(host):
+    """Test that config files for the VNC user were created."""
+    # Test that the ~vnc/.vnc directory was created.
+    f = host.file("/home/vnc/.vnc")
+    assert f.exists
+    assert f.is_directory
+    assert f.user == "vnc"
+    assert f.group == "vnc"
+    assert f.mode == 0o755
+
+    # Test that the ~vnc/.vnc/passwd file was created.
+    f = host.file("/home/vnc/.vnc/passwd")
+    assert f.exists
+    assert f.is_file
+    assert f.user == "vnc"
+    assert f.group == "vnc"
+    assert f.mode == 0o600
+
+    # Test that the ~vnc/.ssh directory was created.
+    f = host.file("/home/vnc/.ssh")
+    assert f.exists
+    assert f.is_directory
+    assert f.user == "vnc"
+    assert f.group == "vnc"
+    assert f.mode == 0o755

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,6 +4,7 @@
 import os
 
 # Third-Party Libraries
+import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -25,3 +26,16 @@ def test_packages(host):
     installed = [package.is_installed for package in packages]
     assert len(pkgs) != 0
     assert all(installed)
+
+
+@pytest.mark.parametrize(
+    "f",
+    [
+        "/home/vnc/.config/autostart/xfce4-power-manager-disable-dpms.desktop",
+        "/home/vnc/.config/autostart/xfce4-screensaver-disable.desktop",
+        "/home/vnc/.config/autostart/xfce4-screensaver-disable-screen-locking.desktop",
+    ],
+)
+def test_autostart_files_exist(host, f):
+    """Test that the file exists."""
+    assert host.file(f).exists

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -54,3 +54,11 @@ def test_autostart_files_exist(host, f):
     assert host.file(f).user == "vnc"
     assert host.file(f).group == "vnc"
     assert host.file(f).mode == 0o644
+
+
+def test_systemd_service_enabled(host):
+    """Test that the VNC systemd service is valid and enabled."""
+    service = host.service("vncserver@1")
+    assert service.is_valid
+    assert service.is_enabled
+    assert not service.is_masked

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,9 +16,9 @@ def test_packages(host):
     """Test that the appropriate packages were installed."""
     distribution = host.system_info.distribution
     if distribution in ["amzn", "fedora"]:
-        pkgs = ["tigervnc-server"]
+        pkgs = ["desktop-file-utils", "tigervnc-server"]
     elif distribution in ["debian", "kali", "ubuntu"]:
-        pkgs = ["tigervnc-standalone-server", "tigervnc-common"]
+        pkgs = ["desktop-file-utils", "tigervnc-standalone-server", "tigervnc-common"]
     else:
         # We don't support this distribution
         assert False, f"Unsupported distribution {distribution}"

--- a/tasks/configure_systemd.yml
+++ b/tasks/configure_systemd.yml
@@ -1,9 +1,9 @@
 ---
 - name: Set up VNC as a systemd service
   ansible.builtin.template:
-    src: vncserver@.service
     dest: /lib/systemd/system/
-    mode: 0644
+    mode: u=rw,g=r,o=r
+    src: vncserver@.service
     # It would be great to use systemd-analyze verify here, but that
     # won't work.  See, for instance, this GitHub issue comment:
     # https://github.com/ansible/ansible/issues/19243#issuecomment-266508074

--- a/tasks/create_vnc_user.yml
+++ b/tasks/create_vnc_user.yml
@@ -15,26 +15,26 @@
   block:
     - name: Create .vnc directory for VNC user
       ansible.builtin.file:
+        group: "{{ vnc_server_username }}"
+        mode: u=rwx,g=rx,o=rx
+        owner: "{{ vnc_server_username }}"
         path: /home/{{ vnc_server_username }}/.vnc
         state: directory
-        mode: 0755
-        owner: "{{ vnc_server_username }}"
-        group: "{{ vnc_server_username }}"
 
     - name: Set VNC password for VNC user
       ansible.builtin.shell: |
         set -o pipefail
         echo {{ vnc_server_password }} | vncpasswd -f > /home/{{ vnc_server_username }}/.vnc/passwd
       args:
-        executable: /bin/bash
         creates: /home/{{ vnc_server_username }}/.vnc/passwd
+        executable: /bin/bash
 
     - name: Set correct permissions for VNC passwd file
       ansible.builtin.file:
-        path: /home/{{ vnc_server_username }}/.vnc/passwd
-        owner: "{{ vnc_server_username }}"
         group: "{{ vnc_server_username }}"
-        mode: 0600
+        mode: u=rw,g=,o=
+        owner: "{{ vnc_server_username }}"
+        path: /home/{{ vnc_server_username }}/.vnc/passwd
 
 # Install an SSH keypair for the VNC user.  This will enable Guacamole
 # to perform file transfers to/from this instance.
@@ -51,17 +51,17 @@
 
     - name: Create .ssh directory for VNC user
       ansible.builtin.file:
+        group: "{{ vnc_server_username }}"
+        mode: u=rwx,g=rx,o=rx
+        owner: "{{ vnc_server_username }}"
         path: "/home/{{ vnc_server_username }}/.ssh"
         state: directory
-        owner: "{{ vnc_server_username }}"
-        group: "{{ vnc_server_username }}"
-        mode: 0755
 
     - name: Install SSH public key for VNC user
       ansible.builtin.copy:
         content: "{{ vnc_server_public_ssh_key }}"
         dest: "/home/{{ vnc_server_username }}/.ssh/id_{{ vnc_server_ssh_key_type | lower }}.pub"
-        mode: 0644
+        mode: u=rw,g=r,o=r
         owner: "{{ vnc_server_username }}"
         group: "{{ vnc_server_username }}"
       when: vnc_server_public_ssh_key|length > 0
@@ -70,16 +70,16 @@
       ansible.builtin.copy:
         content: "{{ vnc_server_private_ssh_key }}"
         dest: "/home/{{ vnc_server_username }}/.ssh/id_{{ vnc_server_ssh_key_type | lower }}"
-        mode: 0600
-        owner: "{{ vnc_server_username }}"
         group: "{{ vnc_server_username }}"
+        mode: u=rw,g=,o=
+        owner: "{{ vnc_server_username }}"
       no_log: true
       when: vnc_server_private_ssh_key|length > 0
 
     - name: Add VNC SSH public key as authorized key
       ansible.posix.authorized_key:
-        user: "{{ vnc_server_username }}"
         key: "{{ vnc_server_public_ssh_key }}"
+        user: "{{ vnc_server_username }}"
       when:
         - vnc_server_public_ssh_key|length > 0
         - vnc_server_private_ssh_key|length > 0

--- a/tasks/disable_screen_locking.yml
+++ b/tasks/disable_screen_locking.yml
@@ -1,6 +1,26 @@
 ---
-# Should this live inside this role?  Can this be generalized?
-- name: Disable screen locking
+- name: Ensure the vnc user's autostart directory exists
   ansible.builtin.file:
-    path: /etc/xdg/autostart/light-locker.desktop
-    state: absent
+    group: "{{ vnc_server_username }}"
+    mode: u=rwx,g=rx,o=rx
+    owner: "{{ vnc_server_username }}"
+    path: /home/{{ vnc_server_username }}/.config/autostart
+    state: directory
+
+- name: Install package that provides desktop-file-validate
+  ansible.builtin.package:
+    name:
+      - desktop-file-utils
+
+- name: Add autostart items to disable screen locking and DPMS
+  ansible.builtin.copy:
+    dest: /home/{{ vnc_server_username }}/.config/autostart/{{ item }}
+    group: "{{ vnc_server_username }}"
+    mode: u=rw,g=r,o=r
+    owner: "{{ vnc_server_username }}"
+    src: "{{ item }}"
+    validate: desktop-file-validate %s
+  loop:
+    - xfce4-power-manager-disable-dpms.desktop
+    - xfce4-screensaver-disable.desktop
+    - xfce4-screensaver-disable-screen-locking.desktop

--- a/tasks/disable_screen_locking.yml
+++ b/tasks/disable_screen_locking.yml
@@ -21,6 +21,7 @@
     src: "{{ item }}"
     validate: desktop-file-validate %s
   loop:
+    - light-locker.desktop
     - xfce4-power-manager-disable-dpms.desktop
     - xfce4-screensaver-disable.desktop
     - xfce4-screensaver-disable-screen-locking.desktop

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,11 +13,11 @@
 - name: Install VNC server
   ansible.builtin.include_tasks: install.yml
 
-- name: Disable screen locking
-  ansible.builtin.include_tasks: disable_screen_locking.yml
-
 - name: Create vnc user
   ansible.builtin.include_tasks: create_vnc_user.yml
 
-- name: Configure SystemD
+- name: Disable screen locking
+  ansible.builtin.include_tasks: disable_screen_locking.yml
+
+- name: Configure systemd
   ansible.builtin.include_tasks: configure_systemd.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible code to correctly disable screen locking and DPMS on XFCE4.

## 💭 Motivation and context ##

1. The previous code did not disable `light-locker` in the preferred way.
2. Kali, at least, no longer uses `light-locker` but instead now uses `xfce4-power-manager` and `xfce4-screensaver` to lock the screen and handle DPMS.

## 🧪 Testing ##

All automated tests pass.  I also built a new Kali AMI for our `dev-a` COOL environment as part of cisagov/kali-packer#184 and verified that it no longer locks the screen automatically.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
